### PR TITLE
Refactor/csdms demo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy this file as .env and replace the placeholders with your local settings
+DGGRID_BINARY_PATH=/full/path/to/dggrid/ # path to folder containing dggrid binary (include trailing slash)

--- a/README.md
+++ b/README.md
@@ -18,26 +18,32 @@ You can use QGIS to visualize some of the model results.
 
 # Step-by-step instruction
 
-1. Create a conda environment named `pyflowline`, and install the `pyflowline` package.
-
-  ```bash
-  conda create --name pyflowline -c conda-forge python pyflowline
-  conda activate pyflowline
-  conda install -c conda-forge numpy gdal matplotlib cartopy geopandas netCDF4
-  ```
-
-2. Download this tutorial.
+- Download this tutorial.
 
    ```bash
    git clone https://github.com/changliao1025/pyflowline_tutorial.git
+   cd pyflowline_tutorial
    ```
 
-3. Run the examples within the `example` folder.
+- Create a conda environment named `pyflowline_tutorial`, and install the `pyflowline` package.
 
-   - Edit the template `configuration` json file to match with your data set paths.
-   - View and visualize model output files.
-   - View normal json file using any text editor such as VS Code.
-   - Visualize `geojson` files using `QGIS`.
+   ```bash
+   # Recommended: use the provided environment.yml file:
+   conda env create -f environment.yml
+   conda activate pyflowline_tutorial
+
+   # By hand:
+   conda create --name pyflowline_tutorial -c conda-forge python pyflowline
+   conda activate pyflowline_tutorial
+   conda install -c conda-forge jupyterlab cmake make numpy gdal netCDF4 mscorefonts matplotlib cartopy geopandas libgdal-arrow-parquet pyearth
+   ```
+
+- Run the examples within the `example` folder.
+  - Edit the template `configuration` json files to match with your data set paths.
+
+- View and visualize model output files.
+  - View normal json files using any text editor such as VS Code.
+  - Visualize `geojson` files using `QGIS`.
 
 # FAQ
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,13 @@ You can use QGIS to visualize some of the model results.
    # By hand:
    conda create --name pyflowline_tutorial -c conda-forge python pyflowline
    conda activate pyflowline_tutorial
-   conda install -c conda-forge jupyterlab cmake make numpy gdal netCDF4 mscorefonts matplotlib cartopy geopandas libgdal-arrow-parquet pyearth
+   conda install -c conda-forge jupyterlab cmake make numpy gdal netCDF4 mscorefonts matplotlib cartopy geopandas libgdal-arrow-parquet python-dotenv pyearth
+   ```
+
+- Optional: copy the `.env.example` file to `.env` and update it with paths specific to your local environment.
+
+   ```bash
+   cp .env.example .env
    ```
 
 - Run the examples within the `example` folder.
@@ -79,4 +85,3 @@ You can use QGIS to visualize some of the model results.
 * Liao et al., (2023). pyflowline: a mesh-independent river network generator for hydrologic models. Journal of Open Source Software, 8(91), 5446, https://doi.org/10.21105/joss.05446
 
 * Liao. C. (2022). Pyflowline: a mesh independent river network generator for hydrologic models. Zenodo. https://doi.org/10.5281/zenodo.6407299
-

--- a/data/yukon/README.md
+++ b/data/yukon/README.md
@@ -1,1 +1,0 @@
-# pyflowline_tutorial

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: pyflowline
+name: pyflowline_tutorial
 channels:
   - conda-forge
 dependencies:
@@ -8,6 +8,7 @@ dependencies:
   - make
   - numpy
   - gdal
+  - netCDF4
   - mscorefonts 
   - matplotlib
   - cartopy

--- a/environment.yml
+++ b/environment.yml
@@ -14,5 +14,6 @@ dependencies:
   - cartopy
   - geopandas
   - libgdal-arrow-parquet
+  - python-dotenv
   - pyearth=0.1.26
   - pyflowline=0.3.10

--- a/examples/yukon/run_dggrid_simulation.py
+++ b/examples/yukon/run_dggrid_simulation.py
@@ -9,6 +9,7 @@ from datetime import date
 #import geopandas as gpd
 import matplotlib.pyplot as plt
 import logging
+from dotenv import load_dotenv
 
 #%% setup logging
 for handler in logging.root.handlers[:]:
@@ -18,8 +19,10 @@ logging.basicConfig(format='%(asctime)s %(message)s')
 logging.warning('is the time pyflowline simulation started.')
 
 #%% Set the path to dggrid
-sPath_dggrid_bin = "/qfs/people/liao313/bin/"
+load_dotenv()
+sPath_dggrid_bin = os.getenv('DGGRID_BINARY_PATH')
 os.environ["PATH"] += os.pathsep + sPath_dggrid_bin
+# Note - iFlag_user_provided_binary must be false
 
 #%% Set workspace paths
 sPath_parent = Path(__file__).resolve().parents[2]
@@ -106,8 +109,8 @@ copy2(sFilename_basins_in, sFilename_basins_configuration_copy)
 # The json file will be overwritten, you may want to make a copy of it first.
 sFilename_configuration = sFilename_configuration_copy
 sFilename_basins = sFilename_basins_configuration_copy
-from pyflowline.configuration.change_json_key_value import change_json_key_value
 
+from pyflowline.configuration.change_json_key_value import change_json_key_value
 change_json_key_value(sFilename_configuration, 'sWorkspace_output', sWorkspace_output) # Output folder
 change_json_key_value(sFilename_configuration, 'sFilename_basins', sFilename_basins) # Individual basin configuration file
 

--- a/examples/yukon/run_dggrid_simulation.py
+++ b/examples/yukon/run_dggrid_simulation.py
@@ -18,7 +18,7 @@ logging.basicConfig(format='%(asctime)s %(message)s')
 logging.warning('is the time pyflowline simulation started.')
 
 #%% Set the path to dggrid
-sPath_dggrid_bin = '/Users/coop558/opt/DGGRID/build/src/apps/dggrid/' # "/qfs/people/liao313/bin/"
+sPath_dggrid_bin = "/qfs/people/liao313/bin/"
 os.environ["PATH"] += os.pathsep + sPath_dggrid_bin
 
 #%% Set workspace paths

--- a/examples/yukon/run_dggrid_simulation.py
+++ b/examples/yukon/run_dggrid_simulation.py
@@ -9,22 +9,23 @@ from datetime import date
 #import geopandas as gpd
 import matplotlib.pyplot as plt
 import logging
+
+#%% setup logging
 for handler in logging.root.handlers[:]:
     logging.root.removeHandler(handler)
 
 logging.basicConfig(format='%(asctime)s %(message)s')
 logging.warning('is the time pyflowline simulation started.')
 
+#%% Set the path to dggrid
+sPath_dggrid_bin = '/Users/coop558/opt/DGGRID/build/src/apps/dggrid/' # "/qfs/people/liao313/bin/"
+os.environ["PATH"] += os.pathsep + sPath_dggrid_bin
 
-os.environ["PATH"] += os.pathsep + "/qfs/people/liao313/bin/"
-from pyflowline.configuration.change_json_key_value import change_json_key_value
-from pyflowline.configuration.read_configuration_file import pyflowline_read_configuration_file
+#%% Set workspace paths
+sPath_parent = Path(__file__).resolve().parents[2]
+print(f"Parent path: {sPath_parent}")
 
-sPath_parent = Path().resolve()
-
-print(sPath_parent)
-
-sWorkspace_data = os.path.join( sPath_parent, 'data', 'yukon' )
+sWorkspace_data = os.path.join( sPath_parent, 'data', 'yukon')
 if not os.path.exists(sWorkspace_data):
     print(sWorkspace_data)
     os.makedirs(sWorkspace_data)
@@ -39,7 +40,7 @@ if not os.path.exists(sWorkspace_output):
     print(sWorkspace_output)
     os.makedirs(sWorkspace_output)
 
-
+#%% Setup temporary workspace for data
 sPath_temp = os.path.join( sPath_parent, 'data', 'tmp' )
 if not os.path.exists(sPath_temp):
     print(sPath_temp)
@@ -63,8 +64,8 @@ shutil.copytree(sPath_temp_data, sWorkspace_input)
 
 shutil.rmtree(sPath_temp)
 
-sFilename_configuration_in = os.path.join(sWorkspace_input , 'pyhexwatershed_yukon_dggrid.json')
-sFilename_basins_in = os.path.join( sWorkspace_input , 'pyflowline_yukon_basins.json')
+sFilename_configuration_in = os.path.join(sWorkspace_input, 'pyhexwatershed_yukon_dggrid.json')
+sFilename_basins_in = os.path.join(sWorkspace_input, 'pyflowline_yukon_basins.json')
 if os.path.isfile(sFilename_configuration_in):
     pass
 else:
@@ -72,7 +73,7 @@ else:
 
 print('Finished the data preparation step.')
 
-
+#%% Define the case parameters
 sRegion = 'yukon'
 sMesh_type = 'dggrid'
 sDggrid_type = 'ISEA3H'
@@ -87,63 +88,60 @@ iDay = today.day
 print("Today's date:", iYear, iMonth, iDay)
 sDate = str(iYear) + str(iMonth).zfill(2) + str(iDay).zfill(2)
 
-
+#%% Set the dggrid mesh resolution
 from pyflowline.mesh.dggrid.create_dggrid_mesh import dggrid_find_resolution_by_index
-dResolution = dggrid_find_resolution_by_index(sDggrid_type,
-                                              iResolution_index)
+dResolution = dggrid_find_resolution_by_index(sDggrid_type, iResolution_index)
 print('Mesh resolution is: ', dResolution, 'm')
 
-sFilename_configuration_copy = os.path.join(
-    sWorkspace_output, 'pyflowline_configuration_copy.json')
+#%% Make copies of the configuration files
+sFilename_configuration_copy = os.path.join(sWorkspace_output, 'pyflowline_configuration_copy.json')
 copy2(sFilename_configuration_in, sFilename_configuration_copy)
 
 # Also copy the basin configuration file to the output directory.
-sFilename_basins_configuration_copy = os.path.join(
-    sWorkspace_output, 'pyflowline_configuration_basins_copy.json')
+sFilename_basins_configuration_copy = os.path.join(sWorkspace_output, 'pyflowline_configuration_basins_copy.json')
 copy2(sFilename_basins_in, sFilename_basins_configuration_copy)
 
+#%% Change configuration parameters
 
 # The json file will be overwritten, you may want to make a copy of it first.
 sFilename_configuration = sFilename_configuration_copy
 sFilename_basins = sFilename_basins_configuration_copy
-# Output folder
-change_json_key_value(sFilename_configuration,
-                                 'sWorkspace_output', sWorkspace_output)
-# Individual basin configuration file
-change_json_key_value(sFilename_configuration,
-                                 'sFilename_basins', sFilename_basins)
+from pyflowline.configuration.change_json_key_value import change_json_key_value
 
-# Boundary to clip mesh
-sFilename_mesh_boundary = realpath(os.path.join(
-    sWorkspace_input, 'boundary.geojson'))
-change_json_key_value(sFilename_configuration,
-                                 'sFilename_mesh_boundary', sFilename_mesh_boundary)
+change_json_key_value(sFilename_configuration, 'sWorkspace_output', sWorkspace_output) # Output folder
+change_json_key_value(sFilename_configuration, 'sFilename_basins', sFilename_basins) # Individual basin configuration file
 
+# Set the domain boundary file, used to clip the mesh
+sFilename_mesh_boundary = realpath(os.path.join(sWorkspace_input, 'boundary.geojson'))
+change_json_key_value(sFilename_configuration, 'sFilename_mesh_boundary', sFilename_mesh_boundary)
 
-# User provided flowline
-oPyflowline = pyflowline_read_configuration_file(sFilename_configuration,
-                                                 iCase_index_in=iCase_index,
-                                                 sMesh_type_in=sMesh_type,
-                                                 iResolution_index_in=iResolution_index,
-                                                 sDate_in=sDate)
+#%% Read the configuration file
+from pyflowline.configuration.read_configuration_file import pyflowline_read_configuration_file
 
+oPyflowline = pyflowline_read_configuration_file(sFilename_configuration, iCase_index_in=iCase_index, sMesh_type_in=sMesh_type, iResolution_index_in=iResolution_index, sDate_in=sDate)
+
+#%% Update some parameters
+
+# Set the approximate outlet location
 dLongitude_outlet_degree = -164.47594
 dLatitude_outlet_degree = 63.04269
 oPyflowline.aBasin[0].dThreshold_small_river = dResolution * 5
 
-oPyflowline.pyflowline_change_model_parameter('dLongitude_outlet_degree',
-                                              dLongitude_outlet_degree,
-                                              iFlag_basin_in=1)
+oPyflowline.pyflowline_change_model_parameter('dLongitude_outlet_degree', dLongitude_outlet_degree, iFlag_basin_in=1)
+oPyflowline.pyflowline_change_model_parameter('dLatitude_outlet_degree', dLatitude_outlet_degree, iFlag_basin_in=1)
 
-oPyflowline.pyflowline_change_model_parameter('dLatitude_outlet_degree',
-                                              dLatitude_outlet_degree,
-                                              iFlag_basin_in=1)
+# Set the path to the user provided flowline
 sFilename_flowline = realpath(os.path.join(sWorkspace_input, 'dggrid10/river_networks.geojson') )
 oPyflowline.pyflowline_change_model_parameter('sFilename_flowline_filter', sFilename_flowline, iFlag_basin_in= 1)
-oPyflowline.pyflowline_change_model_parameter('iFlag_debug', 0, iFlag_basin_in= 1)
 
-#setup the model
+# Turn debugging off
+oPyflowline.pyflowline_change_model_parameter('iFlag_debug', 0, iFlag_basin_in=1)
+
+# Set this flag false if the dggrid binary is on the system path, to let pyflowline find it. Set this flag true if the path to the binary is set in the configuration file.
 oPyflowline.iFlag_user_provided_binary = 0
+
+#%% Setup the model
+
 oPyflowline.pyflowline_setup()
 #oPyflowline.plot( sVariable_in = 'flowline_filter' )
 oPyflowline.pyflowline_flowline_simplification()
@@ -154,6 +152,6 @@ aCell = oPyflowline.pyflowline_mesh_generation()
 oPyflowline.pyflowline_reconstruct_topological_relationship()
 oPyflowline.pyflowline_export()
 #oPyflowline.plot( sVariable_in = 'flowline_conceptual')
-oPyflowline.plot( sVariable_in = 'overlap')
+# oPyflowline.plot( sVariable_in = 'overlap')
 oPyflowline.pyflowline_export_config_to_json()
 print('Finished the simulation.')

--- a/examples/yukon/run_dggrid_simulation.py
+++ b/examples/yukon/run_dggrid_simulation.py
@@ -137,21 +137,29 @@ oPyflowline.pyflowline_change_model_parameter('sFilename_flowline_filter', sFile
 # Turn debugging off
 oPyflowline.pyflowline_change_model_parameter('iFlag_debug', 0, iFlag_basin_in=1)
 
-# Set this flag false if the dggrid binary is on the system path, to let pyflowline find it. Set this flag true if the path to the binary is set in the configuration file.
+# Set this flag false if the dggrid binary is on the system path, to let pyflowline find it. Set this flag true if the path to the binary file is set in the configuration file.
 oPyflowline.iFlag_user_provided_binary = 0
 
 #%% Setup the model
 
 oPyflowline.pyflowline_setup()
-#oPyflowline.plot( sVariable_in = 'flowline_filter' )
+oPyflowline.plot( sVariable_in = 'flowline_filter' )
+
+#%% Flowline simplification
 oPyflowline.pyflowline_flowline_simplification()
-#oPyflowline.plot( sVariable_in = 'flowline_simplified' )
+oPyflowline.plot( sVariable_in = 'flowline_simplified' )
+
+#%% Mesh generation
 oPyflowline.iFlag_mesh_boundary = 1
 aCell = oPyflowline.pyflowline_mesh_generation()
-#oPyflowline.plot( sVariable_in = 'mesh')
+oPyflowline.plot( sVariable_in = 'mesh')
 oPyflowline.pyflowline_reconstruct_topological_relationship()
+
+#%% Export the results
 oPyflowline.pyflowline_export()
-#oPyflowline.plot( sVariable_in = 'flowline_conceptual')
-# oPyflowline.plot( sVariable_in = 'overlap')
+oPyflowline.plot( sVariable_in = 'flowline_conceptual')
+oPyflowline.plot( sVariable_in = 'overlap')
 oPyflowline.pyflowline_export_config_to_json()
+
+# %%
 print('Finished the simulation.')

--- a/notebooks/susquehanna/mpas_example.ipynb
+++ b/notebooks/susquehanna/mpas_example.ipynb
@@ -39,6 +39,7 @@
     "import json\n",
     "from pathlib import Path\n",
     "from os.path import realpath\n",
+    "from datetime import datetime\n",
     "import importlib.util"
    ]
   },
@@ -102,7 +103,7 @@
    "outputs": [],
    "source": [
     "from pyflowline.configuration.read_configuration_file import pyflowline_read_configuration_file\n",
-    "from pyflowline.configuration.change_json_key_value import pyflowline_change_json_key_value"
+    "from pyflowline.configuration.change_json_key_value import change_json_key_value"
    ]
   },
   {
@@ -121,14 +122,14 @@
    "outputs": [],
    "source": [
     "# Set the domain name and the \"parent\" configuration file name.\n",
-    "sDomainName = \"susquehanna\"\n",
+    "sRegion = \"susquehanna\"\n",
     "sFilename_domain_config_in = 'pyflowline_susquehanna_mpas.json'\n",
     "sFilename_basins_config_in = 'pyflowline_susquehanna_basins.json'\n",
     "\n",
     "# Set paths to where the input data exists, and where the outputs are written.\n",
     "sPath_project = str(Path().resolve().parents[1]) \n",
-    "sPath_input = os.path.join(sPath_project, 'data', sDomainName, 'input')\n",
-    "sPath_output = os.path.join(sPath_project, 'data', sDomainName, 'output')\n",
+    "sPath_input = os.path.join(sPath_project, 'data', sRegion, 'input')\n",
+    "sPath_output = os.path.join(sPath_project, 'data', sRegion, 'output')\n",
     "\n",
     "# Set the full path to the domain (parent) basins (child) configuration files.\n",
     "sFilename_domain_config_in = realpath(os.path.join(sPath_input, sFilename_domain_config_in))\n",
@@ -234,7 +235,7 @@
    "source": [
     "The meaning of these json keywords are explained in the [pyflowline documentation](https://pyflowline.readthedocs.io/en/latest/data/data.html#inputs).\n",
     "\n",
-    "For some parameters, we can change them using the following function call. For some other parameters (e.g., path to file), you need to modify the json file using a text editor. If the function returns an error, you should update the json file(s). "
+    "For some parameters, we can change them using a function call, demonstrated below. For some other parameters (e.g., file paths), you need to modify the json file using a text editor. If the function returns an error, you should update the json file(s). "
    ]
   },
   {
@@ -243,7 +244,7 @@
    "id": "33cce0f7",
    "metadata": {},
    "source": [
-    "Now set up some keywords."
+    "Now set up some keywords which define the parameters for this case."
    ]
   },
   {
@@ -256,8 +257,8 @@
     "#set up some parameters\n",
     "sMesh_type = 'mpas'\n",
     "iCase_index = 1\n",
-    "dResolution_meter=5000\n",
-    "sDate='20230101'"
+    "dResolution_meter = 5000 # mesh resolution\n",
+    "sDate = datetime.now().strftime('%Y%m%d')"
    ]
   },
   {
@@ -282,28 +283,22 @@
     "    sPath_input, 'boundary_wgs.geojson'))\n",
     "\n",
     "# Set the path to the mpas file we just downloaded\n",
-    "pyflowline_change_json_key_value(sFilename_domain_config_in, \n",
-    "                      'sFilename_mesh_netcdf', sFilename_mpas_local) \n",
+    "change_json_key_value(sFilename_domain_config_in, 'sFilename_mesh_netcdf', sFilename_mpas_local) \n",
     "\n",
     "# Set the path to the boundary file used to clip the mesh\n",
-    "pyflowline_change_json_key_value(sFilename_domain_config_in, \n",
-    "                      'sFilename_mesh_boundary', sFilename_mesh_boundary) \n",
+    "change_json_key_value(sFilename_domain_config_in,  'sFilename_mesh_boundary', sFilename_mesh_boundary) \n",
     "\n",
     "# Set the path to the individual-basin (\"child\") configuration file\n",
-    "pyflowline_change_json_key_value(sFilename_domain_config_in, \n",
-    "                      'sFilename_basins', sFilename_basins_config_in) \n",
+    "change_json_key_value(sFilename_domain_config_in, 'sFilename_basins', sFilename_basins_config_in) \n",
     "\n",
     "# Set the path to the output folder\n",
-    "pyflowline_change_json_key_value(sFilename_domain_config_in, \n",
-    "                      'sWorkspace_output', sPath_output)\n",
+    "change_json_key_value(sFilename_domain_config_in, 'sWorkspace_output', sPath_output)\n",
     "\n",
     "# Now change basin configuration file\n",
-    "sFilename_flowline = realpath(os.path.join(\n",
-    "    sPath_input, 'flowline.geojson') )\n",
+    "sFilename_flowline = realpath(os.path.join(sPath_input, 'flowline.geojson') )\n",
     "\n",
     "# Set the path to the user-provided flowline. Note that when changing the basin (\"child\") configuration file, set iFlag_basin_in=1.\n",
-    "pyflowline_change_json_key_value(sFilename_basins_config_in, \n",
-    "                      'sFilename_flowline_filter', sFilename_flowline, iFlag_basin_in=1)"
+    "change_json_key_value(sFilename_basins_config_in,  'sFilename_flowline_filter', sFilename_flowline, iFlag_basin_in=1)"
    ]
   },
   {
@@ -317,9 +312,9 @@
     "The first argument to the `pyflowline_read_configuration_file` function is the configuration file filename, followed by name-value keywords that correspond to parameters in the json configuration files.\n",
     "\n",
     "Some useful keyword arguments are:\n",
-    "- iCase_index_in: this is an ID to identify the simulation case\n",
-    "- sMesh_type_in: this specifies the mesh type ('mpas' in this example)\n",
-    "- sDate_in: this specifies the date of the simulation, the final output folder will have a pattern such as 'pyflowline20230901001', where pyflowline is model, 20230901 is the date, and 001 is the case index.\n",
+    "- `iCase_index_in`: this is an arbitrary ID to identify the simulation case.\n",
+    "- `sMesh_type_in`: this specifies the mesh type ('mpas' in this example).\n",
+    "- `sDate_in`: this specifies the date of the simulation, the final output folder will have a pattern such as 'pyflowline20230901001', where pyflowline is model, 20230901 is the date, and 001 is the case index.\n",
     "\n",
     "Call the function to create a pyflowline object."
    ]
@@ -331,9 +326,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "oPyflowline = pyflowline_read_configuration_file(sFilename_domain_config_in, \n",
-    "                                                 iCase_index_in=iCase_index, sMesh_type_in=sMesh_type, \n",
-    "                                                 sDate_in=sDate)"
+    "oPyflowline = pyflowline_read_configuration_file(sFilename_domain_config_in, iCase_index_in=iCase_index, sMesh_type_in=sMesh_type, sDate_in=sDate)"
    ]
   },
   {
@@ -341,11 +334,9 @@
    "id": "7e105e59",
    "metadata": {},
    "source": [
-    "Other than setting the parameter using the read model configuration fucntion, users can also change model parameters after creating the model object.\n",
+    "In addition to the `pyflowline_read_configuration_file` function, users can change model parameters after creating the model object.\n",
     "\n",
-    "In this example, we will change the mesh file name. The function will check the data type, if incorrect data type is provided, it will raise an error.\n",
-    "\n",
-    "Note that because the mpas mesh is unique in that it contains elevation data associated with each mesh cell, we do not need to set the elevation file name."
+    "In this example, we will change the mesh file name."
    ]
   },
   {
@@ -355,10 +346,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "oPyflowline.pyflowline_change_model_parameter('sFilename_mesh_netcdf', \n",
-    "                                              sFilename_mpas_local) \n",
-    "oPyflowline.pyflowline_change_model_parameter('sFilename_mesh_boundary', \n",
-    "                                              sFilename_mesh_boundary)"
+    "oPyflowline.pyflowline_change_model_parameter('sFilename_mesh_netcdf', sFilename_mpas_local)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c4995b08",
+   "metadata": {},
+   "source": [
+    "In general, a digital elevation model (DEM) is not required by `pyflowline`, but is required by `hexwatershed`. If the model configuration file includes the parameter `sFilename_dem`, `pyflowline` will use the DEM file to define the boundary and spatial reference of the domain. In this case, a domain boundary file is not required.\n",
+    "\n",
+    "Alternatively, the user can supply a domain boundary file by setting the `sFilename_mesh_boundary` parameter. This file becomes required if `sFilename_dem` is not provided. \n",
+    "\n",
+    "The MPAS mesh is unique in that it contains elevation data associated with each mesh cell, therefore we don't have a separate DEM file, and instead we need to supply a domain boundary and set the `sFilename_mesh_boundary` parameter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "67789c4e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "oPyflowline.pyflowline_change_model_parameter('sFilename_mesh_boundary', sFilename_mesh_boundary)"
    ]
   },
   {
@@ -368,9 +378,9 @@
    "source": [
     "We can also set parameters for individual basins in the domain. In this example, we only have one basin.\n",
     "\n",
-    "Remember that, each basin can have different parameters, so if you want to set them different (for example, basin 1 has no dam, but basin 2 has dam), you should edit the basin json instead using this function, because change_model_parameter will set all the basin using the same parameter in current version.\n",
+    "Although each basin can have different parameters, `pyflowline_change_model_parameter` does not currently support changing parameters for individual basins (it sets the same parameter value for all of the basins). If you want to set different parameter values for individual basins (for example, basin 1 has no dam, but basin 2 has a dam), you should edit the basin configuration json file directly. \n",
     "\n",
-    "When setting a basin configuration file, we must set the final argument iFlag_basin_in = 1."
+    "When setting a basin configuration file parameter, we must set the final argument `iFlag_basin_in=1`."
    ]
   },
   {
@@ -380,8 +390,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "oPyflowline.pyflowline_change_model_parameter('iFlag_dam', 0, \n",
-    "                                              iFlag_basin_in=1)"
+    "oPyflowline.pyflowline_change_model_parameter('iFlag_dam', 0, iFlag_basin_in=1)"
    ]
   },
   {
@@ -409,9 +418,9 @@
    "id": "e1239843",
    "metadata": {},
    "source": [
-    "Another important setting for basin is the approximate outlet location.\n",
+    "Another important (and required) parameter is the approximate outlet location, which `pyflowline` uses as a starting point for its upstream walk. In a typical workflow, we suggest you plot your flowline in software such as QGIS, visually identify the coordinates, and either type them directly into the model configuration json file, or update them programmatically as shown below.\n",
     "\n",
-    "Set it using the change_model_parameter function."
+    "Set the approximate outlet location coordinates using the `pyflowline_change_model_parameter` function."
    ]
   },
   {
@@ -434,7 +443,7 @@
    "id": "61f5b8ed",
    "metadata": {},
    "source": [
-    "You can check the setting for the single basin as well"
+    "You can check the settings for individual basins as well. Here there is a single basin:"
    ]
   },
   {
@@ -564,7 +573,7 @@
    "id": "fedd7947",
    "metadata": {},
    "source": [
-    "Similarly, we can zoom in using the extent."
+    "We can zoom in using the extent."
    ]
   },
   {
@@ -573,7 +582,7 @@
    "id": "e72a9453",
    "metadata": {},
    "source": [
-    "Next, we will creata a mesh from the global MPAS mesh."
+    "Next, create a mesh for the domain from the global MPAS mesh."
    ]
   },
   {
@@ -584,7 +593,6 @@
    "outputs": [],
    "source": [
     "# Run step 2: create a mesh.\n",
-    "# we can either use a rectangle boundary\n",
     "oPyflowline.iFlag_mesh_boundary = 0 #set to 0 to disable polygon-based\n",
     "oPyflowline.dLongitude_left= -79\n",
     "oPyflowline.dLongitude_right= -74.5\n",
@@ -632,7 +640,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "oPyflowline.iFlag_mesh_boundary = 1\n",
+    "oPyflowline.iFlag_mesh_boundary = 1 #set to 1 to enable polygon-based\n",
     "aCell = oPyflowline.pyflowline_mesh_generation()"
    ]
   },

--- a/notebooks/yukon/dggrid_example.ipynb
+++ b/notebooks/yukon/dggrid_example.ipynb
@@ -1,14 +1,22 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "ca25d727",
+   "metadata": {},
+   "source": [
+    "# PyFlowline Tutorial"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "id": "768807d8-ff92-4289-86eb-c9366edceafe",
    "metadata": {},
    "source": [
-    "Welcome to the PyFlowline tutorial notebook!\n",
+    "Welcome to the PyFlowline tutorial notebook! 👋\n",
     "\n",
-    "This tutorial serves as an example of the PyFlowline application using a dggrid mesh.\n",
+    "This tutorial serves as an example of the PyFlowline application using a DGGRID (Discrete Global Grid) mesh.\n",
     "\n",
     "For additional information on this application and the DGGRID mesh, please refer to the following publication:\n",
     "\n",
@@ -16,7 +24,25 @@
     "\n",
     "If you are running this notebook directly from the Binder platform, then all the dependencies are already installed. Otherwise, you must install the PyFlowline package and its dependencies (and/or update your existing installation/environment). Additionally, visualization requires optional dependency packages (refer to the full documentation installation section).\n",
     "\n",
-    "Feel free to modify the notebook to use a different visualization method as needed. Enjoy exploring PyFlowline!\n"
+    "Feel free to modify the notebook to use a different visualization method as needed. \n",
+    "\n",
+    "Enjoy exploring PyFlowline!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a0b7a2b4",
+   "metadata": {},
+   "source": [
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5a4f5df0",
+   "metadata": {},
+   "source": [
+    "## 1. Preliminaries"
    ]
   },
   {
@@ -53,7 +79,7 @@
    "id": "bf81807a",
    "metadata": {},
    "source": [
-    "Check pyflowline installation."
+    "### Check the pyflowline installation."
    ]
   },
   {
@@ -75,7 +101,7 @@
    "id": "77cba0cf",
    "metadata": {},
    "source": [
-    "Add dggrid into the system path."
+    "### Add dggrid into the system path."
    ]
   },
   {
@@ -85,29 +111,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# If running locally, replace this with the path to the dggrid binary\n",
+    "# If running locally, replace this with the path to the folder containing the dggrid binary\n",
     "sPath_dggrid_bin = os.pathsep + \"/home/jovyan/\"\n",
     "os.environ[\"PATH\"] += sPath_dggrid_bin"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "25edfaeb",
-   "metadata": {},
-   "source": [
-    "Now we can import a few python function within pyflowline."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9ad0e257",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#load the read configuration function\n",
-    "from pyflowline.configuration.change_json_key_value import change_json_key_value\n",
-    "from pyflowline.configuration.read_configuration_file import pyflowline_read_configuration_file"
    ]
   },
   {
@@ -116,7 +122,7 @@
    "id": "025169d4",
    "metadata": {},
    "source": [
-    "Prepare the input/output data structure."
+    "### Prepare the input/output workspace folders."
    ]
   },
   {
@@ -153,7 +159,7 @@
    "id": "09b50234",
    "metadata": {},
    "source": [
-    "Create a temp folder to download data."
+    "### Create a temp folder to download the data requirements."
    ]
   },
   {
@@ -189,11 +195,49 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0f461a2c",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 2. Configuration files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "1a88215a",
    "metadata": {},
    "source": [
-    "pyflowline uses a json file for configuration, an example json file is provided.\n",
-    "check whether a configuration exists."
+    "The pyflowline package uses json configuration files. Example configuration files are provided in the `data/` folder of this repo.\n",
+    "\n",
+    "To configure a new case, pyflowline provides functions to read the configuration files, and programatically change the configuration parameters (json key values)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "77f4bd49",
+   "metadata": {},
+   "source": [
+    "### Import the pyflowline package configuration functions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "97291179",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load functions to read the configuration file and change the json key values.\n",
+    "from pyflowline.configuration.read_configuration_file import pyflowline_read_configuration_file\n",
+    "from pyflowline.configuration.change_json_key_value import change_json_key_value"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11f34cdb",
+   "metadata": {},
+   "source": [
+    "### Set the file names for the domain configuration and basin configuration."
    ]
   },
   {
@@ -203,12 +247,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sFilename_configuration_in = realpath(os.path.join(sWorkspace_input, 'pyhexwatershed_yukon_dggrid.json'))\n",
-    "sFilename_basins_in = realpath( os.path.join( sWorkspace_input, 'pyflowline_yukon_basins.json') )\n",
+    "sFilename_configuration_in = realpath( os.path.join(sWorkspace_input, 'pyhexwatershed_yukon_dggrid.json') )\n",
+    "sFilename_basins_in = realpath( os.path.join(sWorkspace_input, 'pyflowline_yukon_basins.json') )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "67165d97",
+   "metadata": {},
+   "source": [
+    "### Check whether the domain configuration file exists."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "88e70780",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "if os.path.isfile(sFilename_configuration_in):\n",
     "    pass\n",
     "else:\n",
-    "    print('The domain configuration file does not exist: ', sFilename_configuration_in)\n",
+    "    print(f'The domain configuration file does not exist: {sFilename_configuration_in}')\n",
     "\n",
     "print('Finished the data preparation step.')"
    ]
@@ -218,7 +279,7 @@
    "id": "05c3e903",
    "metadata": {},
    "source": [
-    "Check the contents of the json configuration file."
+    "### Check the contents of the json configuration file."
    ]
   },
   {
@@ -242,52 +303,26 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "id": "33cce0f7",
+   "id": "40bef559",
    "metadata": {},
    "source": [
-    "Now set up some keywords."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "52820d49",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Set some parameters.\n",
-    "sRegion = 'yukon'\n",
-    "sMesh_type = 'dggrid'\n",
-    "sDggrid_type = 'ISEA3H'\n",
-    "iCase_index = 1\n",
-    "iResolution_index = 10 # dggrid resolution index\n",
+    "---\n",
+    "## 3. Configure a new case: Yukon River Basin with dggrid mesh.\n",
     "\n",
-    "# Get today's date.\n",
-    "sDate = datetime.now().strftime('%Y%m%d')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "69f442ec",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from pyflowline.mesh.dggrid.create_dggrid_mesh import dggrid_find_resolution_by_index\n",
-    "dResolution = dggrid_find_resolution_by_index(sDggrid_type, iResolution_index)\n",
-    "print(dResolution)"
+    "The pyflowline package uses the OOP approach to manage each simulation. A flowline object—a `flowlinecase`—is created by reading the model configuration file (also referred to as the \"domain\" or \"parent\" configuration file). \n",
+    "\n",
+    "The first step to setting up a new `flowlinecase` is to configure the pyflowline simulation. This can be done by directly editing the json configuration files, or programmatically. Below we demonstrate several ways to achieve this programmatically."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "cc4e7ec0",
+   "id": "6f64ca71",
    "metadata": {},
    "source": [
-    "The pyflowline python package uses the OOP approach to manage each simulation. A pyflowline object is created by reading the configuration file.\n",
+    "### Create copies of the configuration files.\n",
     "\n",
-    "The first argument to the `pyflowline_read_configuration_file` function is the configuration file filename, followed by name-value keywords that correspond to the parameters in the json configuration files."
+    " For this example, instead of editing the template configuration files directly (which overwrites them) we will make copies and edit them."
    ]
   },
   {
@@ -297,7 +332,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#instead of changing the main configuration file directly, we will make copies\n",
     "# Copy the configuration file to the output directory.\n",
     "sFilename_configuration_copy = os.path.join(sWorkspace_output, 'pyflowline_configuration_copy.json')\n",
     "copy2(sFilename_configuration_in, sFilename_configuration_copy)\n",
@@ -312,7 +346,30 @@
    "id": "1a6265f6",
    "metadata": {},
    "source": [
-    "Update a few parameters in the configuration file before we can create the flowline object."
+    "### Change configuration file parameters.\n",
+    "\n",
+    "Now we will update a few parameters in the configuration files. It is often convenient (and/or required) to first set file paths either directly in a text editor, or with the `change_json_key_value` function—which directly modifies the json files—and then later update the parameters for a specific case programmatically using keyword arguments, as demonstrated in the next section. Here, we set the file paths using the `change_json_key_value` function.\n",
+    "\n",
+    "Since the json file will be overwritten, you may want to make a copy of it first. Here we use the copies we created above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f3e6d8f2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sFilename_configuration = sFilename_configuration_copy\n",
+    "sFilename_basins = sFilename_basins_configuration_copy"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0e69e9d7",
+   "metadata": {},
+   "source": [
+    "#### Set the output folder parameter."
    ]
   },
   {
@@ -322,19 +379,95 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# The json file will be overwritten, you may want to make a copy of it first.\n",
-    "sFilename_configuration = sFilename_configuration_copy\n",
-    "sFilename_basins = sFilename_basins_configuration_copy\n",
-    "\n",
-    "# Output folder\n",
-    "change_json_key_value(sFilename_configuration, 'sWorkspace_output', sWorkspace_output)\n",
-    "\n",
-    "# Individual basin configuration file\n",
-    "change_json_key_value(sFilename_configuration, 'sFilename_basins', sFilename_basins)\n",
-    "\n",
-    "# Boundary to clip mesh\n",
+    "change_json_key_value(sFilename_configuration, 'sWorkspace_output', sWorkspace_output)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "58457806",
+   "metadata": {},
+   "source": [
+    "#### Set the basin configuration file name parameter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e097abf4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "change_json_key_value(sFilename_configuration, 'sFilename_basins', sFilename_basins)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11f04d27",
+   "metadata": {},
+   "source": [
+    "#### Set the mesh boundary file name (used to define the domain extent and clip the mesh)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c72c4aff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "sFilename_mesh_boundary = realpath(os.path.join(sWorkspace_input, 'boundary.geojson'))\n",
     "change_json_key_value(sFilename_configuration, 'sFilename_mesh_boundary', sFilename_mesh_boundary)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4ac0d898",
+   "metadata": {},
+   "source": [
+    "**Note**: In Section 6 (see \"Step 2: Create the mesh\"), we set a flag which tells the pyflowline software to use this mesh boundary file for the domain instead of the (optional) DEM file, which isn't used in this example."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "69d7ee4f",
+   "metadata": {},
+   "source": [
+    "#### Set the dggrid binary path.\n",
+    "\n",
+    "The dggrid binary path was added to the Binder environment path at the beginning of this notebook. \n",
+    "\n",
+    "To run in your local environment, either edit the path or use the example below to directly set the full path to the dggrid binary file using the parameter in the configuration file. Note that the iFlag_user_provided_binary flag must also be set if the example below is used."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "137eb9d5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This is intentionally commented out to demonstrate how to set the dggrid binary path if running this notebook in your local environment.\n",
+    "\n",
+    "# sFilename_dggrid = \"\" # set the full path to the dggrid binary file (note: filename, not parent folder) in your local environment\n",
+    "# change_json_key_value(sFilename_configuration, 'sFilename_dggrid', sFilename_dggrid)\n",
+    "# change_json_key_value(sFilename_configuration, 'iFlag_user_provided_binary', 1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "66f877b9",
+   "metadata": {},
+   "source": [
+    "To adapt this example to your workflow, feel free to open the configuration files and directly edit the parameter value pairs, especially workspace paths, for your local setup. Depending on the type of simulation, some of the paths are ignored. Some trial and error may be required, but if you encounter errors, refer to the [pyflowline documentation](https://pyflowline.readthedocs.io) and to the [pyflowline examples](https://github.com/changliao1025/pyflowline/tree/main/examples) in the pyflowline repo."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5a53be0",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 4. Create a PyFlowline object"
    ]
   },
   {
@@ -343,7 +476,69 @@
    "id": "98968ee9",
    "metadata": {},
    "source": [
-    "We can now call the function to create an object."
+    "In the prior section, we used the `change_json_key_value` function to programmatically modify parameters (mainly file paths) in the pyflowline configuration files before setting up a new pyflowline simulation. \n",
+    "\n",
+    "Here, we use the `pyflowline_read_configuration_file` function to create a new `flowlinecase` by **reading the domain configuration file**. The function also accepts name-value arguments to set parameter values on the fly."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "77bae117",
+   "metadata": {},
+   "source": [
+    "### Set keywords to define the case."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "52820d49",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sRegion = 'yukon'\n",
+    "sMesh_type = 'dggrid'\n",
+    "sDggrid_type = 'ISEA3H'\n",
+    "iCase_index = 1 # an arbitrary index used to track simulations\n",
+    "iResolution_index = 10 # dggrid resolution index\n",
+    "sDate = datetime.now().strftime('%Y%m%d') # today's date\n",
+    "print(\"Today's date:\", sDate)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f590b8b4",
+   "metadata": {},
+   "source": [
+    "### Get the dggrid mesh resolution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "69f442ec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyflowline.mesh.dggrid.create_dggrid_mesh import dggrid_find_resolution_by_index\n",
+    "dResolution = dggrid_find_resolution_by_index(sDggrid_type, iResolution_index)\n",
+    "print(f\"DGGRID spatial resolution: {dResolution} m\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fc14e679",
+   "metadata": {},
+   "source": [
+    "### Create a new `flowlinecase`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ba96f2dd",
+   "metadata": {},
+   "source": [
+    "The first argument to the function is the configuration file name, followed by name-value keywords that correspond to parameters in the json configuration files. "
    ]
   },
   {
@@ -353,8 +548,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#the read function accepts several keyword arguments that can be used to change the default parameters.\n",
     "oPyflowline = pyflowline_read_configuration_file(sFilename_configuration, iCase_index_in=iCase_index, sMesh_type_in=sMesh_type, iResolution_index_in=iResolution_index, sDate_in=sDate)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8861ee97",
+   "metadata": {},
+   "source": [
+    "**Note**: The warning message above will be addressed in the next section."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "999e3779",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 5. Change model parameters"
    ]
   },
   {
@@ -363,7 +574,9 @@
    "id": "439971cd",
    "metadata": {},
    "source": [
-    "You can review the setting again."
+    "Model parameters can be updated after creating the model object. In this section, we'll set the basin outlet location, and the path to the input flowline. Note that these parameters are for the *basin configuration*, rather than the *domain* configuration, which we were updating in the prior section.\n",
+    "\n",
+    "Review the case settings before proceeding."
    ]
   },
   {
@@ -377,12 +590,24 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "da973cf4",
+   "metadata": {},
+   "source": [
+    "### Set the basin outlet location coordinates"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "id": "e1239843",
    "metadata": {},
    "source": [
-    "If you are not certain of the outlet location, you can also set them up using:"
+    "The approximate basin outlet location is an important parameter, used by `pyflowline` as a starting point for its upstream walk. Note that this parameter is set in the basin configuration file (also referred to as the \"child\" configuration file).\n",
+    "\n",
+    "In a typical workflow, we suggest to plot your flowline in software such as QGIS, visually identify the outlet coordinates, and either type them directly into the basin configuration file, or update them programmatically as shown below.\n",
+    "\n",
+    "Use the `pyflowline_change_model_parameter` function to set the outlet coordinates. Note that, when updating the *basin* configuration file, set `iFlag_basin_in=1`."
    ]
   },
   {
@@ -392,21 +617,51 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Another important setting for basin is the approximate outlet location\n",
-    "# You can set it using the change_model_parameter function.\n",
+    "# Set the basin outlet coordinates\n",
     "dLongitude_outlet_degree = -164.47594\n",
     "dLatitude_outlet_degree = 63.04269\n",
-    "oPyflowline.aBasin[0].dThreshold_small_river = dResolution * 5\n",
     "\n",
     "oPyflowline.pyflowline_change_model_parameter('dLongitude_outlet_degree', dLongitude_outlet_degree, iFlag_basin_in=1)\n",
     "\n",
-    "oPyflowline.pyflowline_change_model_parameter('dLatitude_outlet_degree', dLatitude_outlet_degree, iFlag_basin_in=1)\n",
-    "\n",
+    "oPyflowline.pyflowline_change_model_parameter('dLatitude_outlet_degree', dLatitude_outlet_degree, iFlag_basin_in=1) # set iFlag_basin_in=1 for basin configuration"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7c7e59b1",
+   "metadata": {},
+   "source": [
+    "### Set the input flowline filename\n",
+    "(This is the missing file `flowlinecase` warned about in the prior section)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8f218b03",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "sFilename_flowline = realpath(os.path.join(sWorkspace_input, 'dggrid10/river_networks.geojson') )\n",
-    "\n",
-    "oPyflowline.pyflowline_change_model_parameter('sFilename_flowline_filter', sFilename_flowline, iFlag_basin_in=1)\n",
-    "\n",
-    "oPyflowline.pyflowline_change_model_parameter('iFlag_debug', 0, iFlag_basin_in=1)\n"
+    "oPyflowline.pyflowline_change_model_parameter('sFilename_flowline_filter', sFilename_flowline, iFlag_basin_in=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "79e69d7e",
+   "metadata": {},
+   "source": [
+    "### Turn debugging off"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c9dd23de",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "oPyflowline.pyflowline_change_model_parameter('iFlag_debug', 0, iFlag_basin_in=1)"
    ]
   },
   {
@@ -414,7 +669,9 @@
    "id": "61f5b8ed",
    "metadata": {},
    "source": [
-    "You can check the setting for the single basin as well"
+    "### Setting parameters for individual basins\n",
+    "\n",
+    "In this example, the domain is comprised of a single basin, but when there are multiple basins, their parameters can be viewed and set by indexing into them using the following syntax."
    ]
   },
   {
@@ -424,7 +681,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(oPyflowline.aBasin[0].tojson())"
+    "# Check the setting for a single basin\n",
+    "print(oPyflowline.aBasin[0].tojson())\n",
+    "\n",
+    "# Set the flowline river length threshold\n",
+    "oPyflowline.aBasin[0].dThreshold_small_river = dResolution * 5"
    ]
   },
   {
@@ -433,7 +694,18 @@
    "id": "c432a723",
    "metadata": {},
    "source": [
-    "After the case object was created, we can set up the model."
+    "---\n",
+    "## 6. Run a PyFlowline simulation\n",
+    "\n",
+    "After the case object is created, we can set up the model and run each step of the pyflowline algorithm, visualizing the results as we go."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "894ac67f",
+   "metadata": {},
+   "source": [
+    "### Setup the model"
    ]
   },
   {
@@ -443,8 +715,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#setup the model\n",
-    "oPyflowline.iFlag_user_provided_binary = 0\n",
+    "oPyflowline.iFlag_user_provided_binary = 0 # set = 1 if setting the path to the binary\n",
     "oPyflowline.pyflowline_setup()"
    ]
   },
@@ -454,7 +725,7 @@
    "id": "39507b33",
    "metadata": {},
    "source": [
-    "Before any operation, we can visualize the original or raw flowline dataset. "
+    "Before running any operations, we can visualize the original or raw flowline dataset. "
    ]
   },
   {
@@ -518,13 +789,20 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "c76723a5",
+   "metadata": {},
+   "source": [
+    "### Step 1: Flowline simplification"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "689984cb",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Run step 1: flowline simplification.\n",
     "oPyflowline.pyflowline_flowline_simplification();"
    ]
   },
@@ -535,17 +813,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#can we can also use built-in visualization method\n",
+    "# Visualize the result using a built-in visualization method.\n",
     "oPyflowline.plot( sVariable_in = 'flowline_simplified' )"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "id": "7c786cb7",
-   "metadata": {},
-   "source": [
-    "Check the result using a plot."
    ]
   },
   {
@@ -555,6 +824,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Check the result using a custom plot.\n",
     "sFilename_geojson = oPyflowline.aBasin[0].sFilename_flowline_simplified\n",
     "gdf = gpd.read_file(sFilename_geojson)\n",
     "gdf.plot()\n",
@@ -562,21 +832,11 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "id": "fedd7947",
+   "id": "daceec73",
    "metadata": {},
    "source": [
-    "Similarly, we can zoom in using the extent."
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "id": "e72a9453",
-   "metadata": {},
-   "source": [
-    "Next, we will creata a mesh from the global MPAS mesh."
+    "### Step 2: Create the mesh"
    ]
   },
   {
@@ -586,18 +846,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Run step 2: create a mesh.\n",
-    "# We can either use a rectangle boundary\n",
+    "# Set the flag to use the provided sFilename_mesh_boundary file\n",
     "oPyflowline.iFlag_mesh_boundary = 1\n",
     "aCell = oPyflowline.pyflowline_mesh_generation()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "fa237d77",
-   "metadata": {},
-   "source": [
-    "Visualize the mesh boundary we provided earlier."
    ]
   },
   {
@@ -607,18 +858,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Visualize the mesh boundary we provided earlier.\n",
     "sFilename_geojson = oPyflowline.sFilename_mesh_boundary\n",
     "gdf = gpd.read_file(sFilename_geojson)\n",
     "gdf.plot()\n",
     "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a3a602d8",
-   "metadata": {},
-   "source": [
-    "Now visualize the generated mesh."
    ]
   },
   {
@@ -628,6 +872,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Visualize the generated mesh using a custom plot.\n",
     "sFilename_geojson = oPyflowline.sFilename_mesh\n",
     "gdf = gpd.read_file(sFilename_geojson)\n",
     "gdf.plot()\n",
@@ -641,16 +886,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Visualize the generated mesh using a built-in visualization method.\n",
     "oPyflowline.plot( sVariable_in = 'mesh')"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "id": "29e58f9b",
+   "id": "8c16d92b",
    "metadata": {},
    "source": [
-    "we can also use a polygon to create a mesh"
+    "### Step 3: Create the conceptual flowline"
    ]
   },
   {
@@ -659,7 +904,7 @@
    "id": "9d8c3d26",
    "metadata": {},
    "source": [
-    "Last, we can generate the conceptual flowline. We refer to the final flowline as \"conceptual\" because it has been modified relative to the original, input flowline, which often represents a \"real\" flowline. The conceptual flowline has been simplified (e.g., small reaches, loops, and braided channels removed) and adjusted to align with the mesh. These modifications ensure the final flowline is suitable for hydrological modeling, while remaining consistent with the real flowline."
+    "Last, we can generate the conceptual flowline. We refer to the final flowline as \"conceptual\" because it has been modified relative to the input flowline, which often represents a \"real\" flowline. The conceptual flowline has been simplified (e.g., small reaches, loops, and braided channels removed) and adjusted to align with the mesh. These modifications ensure the final flowline is suitable for hydrological modeling, while remaining consistent with the real flowline."
    ]
   },
   {
@@ -669,8 +914,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Run Step 3: create the \"conceptual\" (topological) flowline.\n",
     "oPyflowline.pyflowline_reconstruct_topological_relationship();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35e41edb",
+   "metadata": {},
+   "source": [
+    "Visualize the conceptual flowline using a built-in method."
    ]
   },
   {
@@ -684,12 +936,11 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "id": "73df1fb2",
+   "id": "d3072c75",
    "metadata": {},
    "source": [
-    "Now we can overlap mesh with flowline. Read the datasets into memory to plot them."
+    "Visualize the result by overlapping the mesh with the flowline using a custom plot."
    ]
   },
   {
@@ -699,7 +950,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Plot the mesh, the input flowline, and the final conceptual flowline\n",
+    "# Read the datasets into memory\n",
     "sFilename_mesh = oPyflowline.sFilename_mesh\n",
     "sFilename_input_flowline = oPyflowline.aBasin[0].sFilename_flowline_filter\n",
     "sFilename_conceptual_flowline = oPyflowline.aBasin[0].sFilename_flowline_conceptual\n",
@@ -709,26 +960,19 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "7c5a7f3f",
-   "metadata": {},
-   "source": [
-    "Create the plot"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "id": "92003dd1",
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Plot the input flowline, and the final conceptual flowline\n",
     "fig, ax = plt.subplots()\n",
     "gdf1.plot(ax=ax, facecolor='lightgrey', edgecolor='black', alpha=0.3, label='Mesh')\n",
     "gdf2.plot(ax=ax, color='deepskyblue', linewidth=3, label='Input Flowline')\n",
     "gdf3.plot(ax=ax, color='darkred', linewidth=1, label='Conceptual Flowline')\n",
     "\n",
-    "# handles for legend\n",
+    "# handles for the legend\n",
     "mesh_patch = mpatches.Patch(facecolor='lightgrey', label='Mesh', edgecolor='black', alpha=0.3)\n",
     "input_line = plt.Line2D([0], [0], color='deepskyblue', label='Input Flowline')\n",
     "conceptual_line = plt.Line2D([0], [0], color='darkred', label='Conceptual Flowline')\n",
@@ -766,7 +1010,7 @@
    "id": "33ce7f70",
    "metadata": {},
    "source": [
-    "After this, we can save the model output into a json file."
+    "### Save the model output into a json file"
    ]
   },
   {
@@ -807,7 +1051,7 @@
    "id": "e2f1bea7",
    "metadata": {},
    "source": [
-    "Congratulations! You have successfully finished a pyflowline simulation."
+    "### Congratulations! You have successfully finished a pyflowline simulation. 🎉"
    ]
   }
  ],
@@ -827,7 +1071,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.19"
+   "version": "3.12.3"
   },
   "vscode": {
    "interpreter": {

--- a/notebooks/yukon/dggrid_example.ipynb
+++ b/notebooks/yukon/dggrid_example.ipynb
@@ -7,7 +7,6 @@
    "metadata": {},
    "source": [
     "Welcome to the PyFlowline tutorial notebook!\n",
-    "This is a tutorial pyflowline notebook.\n",
     "\n",
     "This tutorial serves as an example of the PyFlowline application using a dggrid mesh.\n",
     "\n",
@@ -15,7 +14,7 @@
     "\n",
     "Liao, C., Engwirda, D., Cooper, M., Li, M., and Fang, Y.: Discrete Global Grid System-based Flow Routing Datasets in the Amazon and Yukon Basins, Earth Syst. Sci. Data Discuss. [preprint], https://doi.org/10.5194/essd-2023-398, in review, 2024.\n",
     "\n",
-    "If you are running this notebook directly from the Binder platform, then all the dependencies are already installed. Otherwise, you must install the PyFlowline package and its dependencies. Additionally, visualization requires optional dependency packages (refer to the full documentation installation section).\n",
+    "If you are running this notebook directly from the Binder platform, then all the dependencies are already installed. Otherwise, you must install the PyFlowline package and its dependencies (and/or update your existing installation/environment). Additionally, visualization requires optional dependency packages (refer to the full documentation installation section).\n",
     "\n",
     "Feel free to modify the notebook to use a different visualization method as needed. Enjoy exploring PyFlowline!\n"
    ]
@@ -43,9 +42,10 @@
     "from os.path import realpath\n",
     "import importlib.util\n",
     "from shutil import copy2\n",
-    "from datetime import date\n",
+    "from datetime import datetime\n",
     "import geopandas as gpd\n",
-    "import matplotlib.pyplot as plt"
+    "import matplotlib.pyplot as plt\n",
+    "import matplotlib.patches as mpatches"
    ]
   },
   {
@@ -85,7 +85,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "os.environ[\"PATH\"] += os.pathsep + \"/home/jovyan/\""
+    "# If running locally, replace this with the path to the dggrid binary\n",
+    "# sPath_dggrid_bin = os.pathsep + \"/home/jovyan/\"\n",
+    "sPath_dggrid_bin = \"/Users/coop558/opt/DGGRID/build/src/apps/dggrid/\"\n",
+    "os.environ[\"PATH\"] += sPath_dggrid_bin"
    ]
   },
   {
@@ -114,7 +117,7 @@
    "id": "025169d4",
    "metadata": {},
    "source": [
-    "Preperae the input/output data structure."
+    "Prepare the input/output data structure."
    ]
   },
   {
@@ -125,23 +128,25 @@
    "outputs": [],
    "source": [
     "sPath_notebook = Path().resolve()\n",
-    "sPath_parent = str(Path().resolve().parents[1])\n",
-    "print(sPath_parent)\n",
+    "sPath_parent = str(sPath_notebook.parents[1])\n",
+    "print(f\"Parent path: {sPath_parent}\")\n",
     "\n",
-    "sWorkspace_data = os.path.join( sPath_parent, 'data', 'yukon' )\n",
+    "sWorkspace_data = os.path.join(sPath_parent, 'data', 'yukon')\n",
     "if not os.path.exists(sWorkspace_data):\n",
     "    print(sWorkspace_data)\n",
     "    os.makedirs(sWorkspace_data)\n",
     "\n",
-    "sWorkspace_input = os.path.join( sWorkspace_data, 'input')\n",
+    "sWorkspace_input = os.path.join(sWorkspace_data, 'input')\n",
     "if not os.path.exists(sWorkspace_input):\n",
     "    print(sWorkspace_input)\n",
     "    os.makedirs(sWorkspace_input)\n",
     "\n",
-    "sWorkspace_output = os.path.join( sWorkspace_data, 'output')\n",
+    "sWorkspace_output = os.path.join(sWorkspace_data, 'output')\n",
     "if not os.path.exists(sWorkspace_output):\n",
     "    print(sWorkspace_output)\n",
-    "    os.makedirs(sWorkspace_output)"
+    "    os.makedirs(sWorkspace_output)\n",
+    "\n",
+    "print(f\"Output path: {sWorkspace_output}\")"
    ]
   },
   {
@@ -159,7 +164,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sPath_temp = os.path.join( sPath_parent, 'data', 'tmp' )\n",
+    "sPath_temp = os.path.join(sPath_parent, 'data', 'tmp')\n",
     "if not os.path.exists(sPath_temp):\n",
     "    print(sPath_temp)\n",
     "    os.makedirs(sPath_temp)\n",
@@ -199,8 +204,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sFilename_configuration_in = realpath(os.path.join(sWorkspace_input , 'pyhexwatershed_yukon_dggrid.json'))\n",
-    "sFilename_basins_in = realpath( os.path.join( sWorkspace_input , 'pyflowline_yukon_basins.json') )\n",
+    "sFilename_configuration_in = realpath(os.path.join(sWorkspace_input, 'pyhexwatershed_yukon_dggrid.json'))\n",
+    "sFilename_basins_in = realpath( os.path.join( sWorkspace_input, 'pyflowline_yukon_basins.json') )\n",
     "if os.path.isfile(sFilename_configuration_in):\n",
     "    pass\n",
     "else:\n",
@@ -260,13 +265,8 @@
     "iCase_index = 1\n",
     "iResolution_index = 10 # dggrid resolution index\n",
     "\n",
-    "# Get today's year, month and day.\n",
-    "today = date.today()\n",
-    "iYear = today.year\n",
-    "iMonth = today.month\n",
-    "iDay = today.day\n",
-    "print(\"Today's date:\", iYear, iMonth, iDay)\n",
-    "sDate = str(iYear) + str(iMonth).zfill(2) + str(iDay).zfill(2)"
+    "# Get today's date.\n",
+    "sDate = datetime.now().strftime('%Y%m%d')"
    ]
   },
   {
@@ -277,8 +277,7 @@
    "outputs": [],
    "source": [
     "from pyflowline.mesh.dggrid.create_dggrid_mesh import dggrid_find_resolution_by_index\n",
-    "dResolution = dggrid_find_resolution_by_index(sDggrid_type,\n",
-    "                                              iResolution_index)\n",
+    "dResolution = dggrid_find_resolution_by_index(sDggrid_type, iResolution_index)\n",
     "print(dResolution)"
    ]
   },
@@ -301,13 +300,11 @@
    "source": [
     "#instead of changing the main configuration file directly, we will make copies\n",
     "# Copy the configuration file to the output directory.\n",
-    "sFilename_configuration_copy = os.path.join(\n",
-    "    sWorkspace_output, 'pyflowline_configuration_copy.json')\n",
+    "sFilename_configuration_copy = os.path.join(sWorkspace_output, 'pyflowline_configuration_copy.json')\n",
     "copy2(sFilename_configuration_in, sFilename_configuration_copy)\n",
     "\n",
     "# Also copy the basin configuration file to the output directory.\n",
-    "sFilename_basins_configuration_copy = os.path.join(\n",
-    "    sWorkspace_output, 'pyflowline_configuration_basins_copy.json')\n",
+    "sFilename_basins_configuration_copy = os.path.join(sWorkspace_output, 'pyflowline_configuration_basins_copy.json')\n",
     "copy2(sFilename_basins_in, sFilename_basins_configuration_copy)"
    ]
   },
@@ -329,19 +326,27 @@
     "# The json file will be overwritten, you may want to make a copy of it first.\n",
     "sFilename_configuration = sFilename_configuration_copy\n",
     "sFilename_basins = sFilename_basins_configuration_copy\n",
+    "\n",
     "# Output folder\n",
-    "change_json_key_value(sFilename_configuration,\n",
-    "                                 'sWorkspace_output', sWorkspace_output)\n",
+    "change_json_key_value(sFilename_configuration, 'sWorkspace_output', sWorkspace_output)\n",
     "\n",
     "# Individual basin configuration file\n",
-    "change_json_key_value(sFilename_configuration,\n",
-    "                                 'sFilename_basins', sFilename_basins)\n",
+    "change_json_key_value(sFilename_configuration, 'sFilename_basins', sFilename_basins)\n",
     "\n",
     "# Boundary to clip mesh\n",
-    "sFilename_mesh_boundary = realpath(os.path.join(\n",
-    "    sWorkspace_input, 'boundary.geojson'))\n",
-    "change_json_key_value(sFilename_configuration,\n",
-    "                                 'sFilename_mesh_boundary', sFilename_mesh_boundary)"
+    "sFilename_mesh_boundary = realpath(os.path.join(sWorkspace_input, 'boundary.geojson'))\n",
+    "change_json_key_value(sFilename_configuration, 'sFilename_mesh_boundary', sFilename_mesh_boundary)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "137eb9d5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Dggrid binary\n",
+    "change_json_key_value(sFilename_configuration, 'sFilename_dggrid', '/Users/coop558/opt/DGGRID/build/src/apps/dggrid/dggrid')"
    ]
   },
   {
@@ -361,11 +366,7 @@
    "outputs": [],
    "source": [
     "#the read function accepts several keyword arguments that can be used to change the default parameters.\n",
-    "oPyflowline = pyflowline_read_configuration_file(sFilename_configuration,\n",
-    "                                                 iCase_index_in=iCase_index,\n",
-    "                                                 sMesh_type_in=sMesh_type,\n",
-    "                                                 iResolution_index_in=iResolution_index,\n",
-    "                                                 sDate_in=sDate)"
+    "oPyflowline = pyflowline_read_configuration_file(sFilename_configuration, iCase_index_in=iCase_index, sMesh_type_in=sMesh_type, iResolution_index_in=iResolution_index, sDate_in=sDate)"
    ]
   },
   {
@@ -409,16 +410,15 @@
     "dLatitude_outlet_degree = 63.04269\n",
     "oPyflowline.aBasin[0].dThreshold_small_river = dResolution * 5\n",
     "\n",
-    "oPyflowline.pyflowline_change_model_parameter('dLongitude_outlet_degree',\n",
-    "                                              dLongitude_outlet_degree,\n",
-    "                                              iFlag_basin_in=1)\n",
+    "oPyflowline.pyflowline_change_model_parameter('dLongitude_outlet_degree', dLongitude_outlet_degree, iFlag_basin_in=1)\n",
     "\n",
-    "oPyflowline.pyflowline_change_model_parameter('dLatitude_outlet_degree',\n",
-    "                                              dLatitude_outlet_degree,\n",
-    "                                              iFlag_basin_in=1)\n",
+    "oPyflowline.pyflowline_change_model_parameter('dLatitude_outlet_degree', dLatitude_outlet_degree, iFlag_basin_in=1)\n",
+    "\n",
     "sFilename_flowline = realpath(os.path.join(sWorkspace_input, 'dggrid10/river_networks.geojson') )\n",
-    "oPyflowline.pyflowline_change_model_parameter('sFilename_flowline_filter', sFilename_flowline, iFlag_basin_in= 1)\n",
-    "oPyflowline.pyflowline_change_model_parameter('iFlag_debug', 0, iFlag_basin_in= 1)\n"
+    "\n",
+    "oPyflowline.pyflowline_change_model_parameter('sFilename_flowline_filter', sFilename_flowline, iFlag_basin_in=1)\n",
+    "\n",
+    "oPyflowline.pyflowline_change_model_parameter('iFlag_debug', 0, iFlag_basin_in=1)\n"
    ]
   },
   {
@@ -456,7 +456,7 @@
    "outputs": [],
    "source": [
     "#setup the model\n",
-    "oPyflowline.iFlag_user_provided_binary = 0\n",
+    "oPyflowline.iFlag_user_provided_binary = 1\n",
     "oPyflowline.pyflowline_setup()"
    ]
   },
@@ -605,11 +605,9 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "id": "fa237d77",
    "metadata": {},
-   "outputs": [],
    "source": [
     "Visualize the mesh boundary we provided earlier."
    ]
@@ -628,11 +626,9 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "id": "a3a602d8",
    "metadata": {},
-   "outputs": [],
    "source": [
     "Now visualize the generated mesh."
    ]
@@ -644,7 +640,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Visualize the mesh\n",
     "sFilename_geojson = oPyflowline.sFilename_mesh\n",
     "gdf = gpd.read_file(sFilename_geojson)\n",
     "gdf.plot()\n",
@@ -706,7 +701,7 @@
    "id": "73df1fb2",
    "metadata": {},
    "source": [
-    "Now we can overlap mesh with flowline."
+    "Now we can overlap mesh with flowline. Read the datasets into memory to plot them."
    ]
   },
   {
@@ -716,14 +711,46 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Plot both the mesh and the flowline\n",
+    "# Plot the mesh, the input flowline, and the final conceptual flowline\n",
     "sFilename_mesh = oPyflowline.sFilename_mesh\n",
+    "sFilename_input_flowline = oPyflowline.aBasin[0].sFilename_flowline_filter\n",
     "sFilename_conceptual_flowline = oPyflowline.aBasin[0].sFilename_flowline_conceptual\n",
     "gdf1 = gpd.read_file(sFilename_mesh)\n",
-    "gdf2 = gpd.read_file(sFilename_conceptual_flowline)\n",
+    "gdf2 = gpd.read_file(sFilename_input_flowline)\n",
+    "gdf3 = gpd.read_file(sFilename_conceptual_flowline)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7c5a7f3f",
+   "metadata": {},
+   "source": [
+    "Create the plot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "92003dd1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "fig, ax = plt.subplots()\n",
-    "gdf1.plot(ax=ax, color='blue')\n",
-    "gdf2.plot(ax=ax, color='red')\n",
+    "gdf1.plot(ax=ax, facecolor='lightgrey', edgecolor='black', alpha=0.3, label='Mesh')\n",
+    "gdf2.plot(ax=ax, color='deepskyblue', linewidth=3, label='Input Flowline')\n",
+    "gdf3.plot(ax=ax, color='darkred', linewidth=1, label='Conceptual Flowline')\n",
+    "\n",
+    "# handles for legend\n",
+    "mesh_patch = mpatches.Patch(facecolor='lightgrey', label='Mesh', edgecolor='black', alpha=0.3)\n",
+    "input_line = plt.Line2D([0], [0], color='deepskyblue', label='Input Flowline')\n",
+    "conceptual_line = plt.Line2D([0], [0], color='darkred', label='Conceptual Flowline')\n",
+    "\n",
+    "ax.legend(handles=[mesh_patch, input_line, conceptual_line], loc='lower left')\n",
+    "ax.set_title('Comparison of Input and Conceptual Flowlines')\n",
+    "ax.set_xlabel(\"Longitude\")\n",
+    "ax.set_ylabel(\"Latitude\")\n",
+    "ax.set_xticks([])\n",
+    "ax.set_yticks([])\n",
     "plt.show()"
    ]
   },

--- a/notebooks/yukon/dggrid_example.ipynb
+++ b/notebooks/yukon/dggrid_example.ipynb
@@ -86,8 +86,7 @@
    "outputs": [],
    "source": [
     "# If running locally, replace this with the path to the dggrid binary\n",
-    "# sPath_dggrid_bin = os.pathsep + \"/home/jovyan/\"\n",
-    "sPath_dggrid_bin = \"/Users/coop558/opt/DGGRID/build/src/apps/dggrid/\"\n",
+    "sPath_dggrid_bin = os.pathsep + \"/home/jovyan/\"\n",
     "os.environ[\"PATH\"] += sPath_dggrid_bin"
    ]
   },
@@ -339,17 +338,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "137eb9d5",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Dggrid binary\n",
-    "change_json_key_value(sFilename_configuration, 'sFilename_dggrid', '/Users/coop558/opt/DGGRID/build/src/apps/dggrid/dggrid')"
-   ]
-  },
-  {
    "attachments": {},
    "cell_type": "markdown",
    "id": "98968ee9",
@@ -456,7 +444,7 @@
    "outputs": [],
    "source": [
     "#setup the model\n",
-    "oPyflowline.iFlag_user_provided_binary = 1\n",
+    "oPyflowline.iFlag_user_provided_binary = 0\n",
     "oPyflowline.pyflowline_setup()"
    ]
   },


### PR DESCRIPTION
### Summary

This PR mainly reorganizes and formats the notebook for clarity. I added a small environment setup adjustment and fixed a path issue, both in the .py example script (not the ipynb - thus no effect on Binder). 

Note - if you review each commit, you'll notice some path incompatibilities, but they are all fixed in later commits. You should be able to accept this and merge it without any issues. I paid careful attention to Binder compatibility, but I suggest you read the notebook to check for any conceptual misunderstandings.

### Detailed Changes
  - Added a method using dotenv to get the `dggrid` binary path in the .py example file. This change does not affect the ipynb file or the Binder setup, its just for user convenience when running the examples in a local environment.
  
  - Reorganize the Yukon demo Jupyter notebook (this is the main contribution of this PR). Add section breaks and detailed notes. This is aimed at the readability and usability of the notebook, making it easier for new users to understand the workflow without altering any core functionalities (thus it should run in Binder no problem).

  - Renamed the Conda environment to `pyflowline_tutorial` and reordered the setup steps in the README to guide users to download the tutorial first, so the `environment.yml` file exists locally before the environment setup begins.

