### PR TITLE
Refactor/dggrid example

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,30 @@ This is a short course for the PyFlowline model.
 
 PyFlowline: a mesh independent river network generator for hydrologic models.
 
-For full details of the model, please refer to our papers and the PyFlowline [documentation](https://pyflowline.readthedocs.io/).
+For full details of the model, please refer to our [papers](#references) and the PyFlowline [documentation](https://pyflowline.readthedocs.io/).
+
+Note that PyFlowline works hand in hand with Hexwatershed. Users interested in the full end-to-end watershed processing workflow enabled by Hexwatershed may wish to visit the [hexwatershed_tutorial](https://github.com/changliao1025/hexwatershed_tutorial).
+
+# Getting Started
+
+If you're just getting started, here's what we recommend:
+
+- Right click on the `launch|binder` link at the top of this page.
+- Open the link in a new window or tab.
+- Grab a coffee while the Binder environment starts up.
+- Run the interactive notebook from within the Binder environment.
+  - `notebooks/yukon/dggrid_example.ipynb`.
+- If the Binder environment fails to load, please open the notebook in your local Jupyter notebook environment.
+  - To run the notebook locally, refer to the [requirements](#requirements).
+  - Otherwise, read the notebook at your liesure to learn about PyFlowline.
+
+_**Please note**_: This repository is specifically designed to host the interactive Binder notebook linked at the top of this page. Binder provides a self-contained environment with all software dependencies installed. Once loaded, use the Binder environment to run the `dggrid_example.ipynb` Jupyter notebook. This interactive tutorial demonstrates how to use the Pyflowline software to generate flow networks on a dggrid (Discrete Global Grid) system mesh for hydrologic modeling, with no coding or software installation required.
+
+To run the example notebooks locally, familiarity with the Python coding ecosystem is required. Please read the instructions below.
 
 # Requirements
 
-You need an internet connection to install the package using Python Pip or Conda (recommended).
+You need an internet connection to install the Pyflowline package and its dependencies using Python Pip or Conda. We recommended Conda.
 
 You can use Visual Studio Code to run the Python examples.
 
@@ -46,16 +65,28 @@ You can use QGIS to visualize some of the model results.
 
 - Run the examples within the `example` folder.
   - Edit the template `configuration` json files to match with your data set paths.
+  - Trial and error may be required.
 
 - View and visualize model output files.
   - View normal json files using any text editor such as VS Code.
   - Visualize `geojson` files using `QGIS`.
 
+# Building dggrid
+
+To run the tutorial locally you need to install [dggrid](https://github.com/sahrk/DGGRID). To install dggrid, follow the instructions [here](https://github.com/sahrk/DGGRID/blob/master/INSTALL.md).
+
+When building dggrid, it will be linked to gdal. If dggrid is installed while the `pyflowline_tutorial` conda environment is activated, then (unless configured otherwise) cmake will find and link dggrid against the gdal version installed into this environment by conda. If the `pyflowline_tutorial` environment is later removed, or for any reason gdal is uninstalled from this environment, dggrid will break. So we recommend to deactivate the `pyflowline_tutorial` environment and link dggrid against a stable gdal installation on your local machine. This could be a gdal installed with `brew`, or `pipx`, or in a general purpose environment managed by `pyenv-virtualenv` or `conda`. Depending on your choice, this will also ensure dggrid is available for use outside of this tutorial. To run the examples, reactivate your `pyflowline_tutorial` environment.
+
+# Advanced use
+
+Users who plan to use the software in their own work may wish to create a conda environment named `pyflowline` (rather than `pyflowline_tutorial`). Better yet, since `pyflowline` users will almost certainly also use [hexwatershed](https://github.com/changliao1025/pyhexwatershed), users may wish to create a single conda environment named `hexwatershed` using the `environment.yml` file over at the [hexwatershed_tutorial](https://github.com/changliao1025/hexwatershed_tutorial), which contains all of the dependencies required by `pyflowline` plus the `hexwatershed` ones. This `hexwatershed` environment can then be used for both `pyflowline` and `hexwatershed` related workflows.
+
 # FAQ
 
-1. Why import `GDAL` failed?
+1. Why did `import GDAL` fail?
 
-   Consider using the `conda-forge` channel.
+   - Consider using the `conda-forge` channel to install `GDAL`.
+   - Ensure the `GDAL` bindings installed with conda are properly linked against the gdal library installed on your local machine. See the instructions [here](https://pypi.org/project/GDAL/).
 
 2. `proj` related issue https://github.com/OSGeo/gdal/issues/1546
 
@@ -80,8 +111,8 @@ You can use QGIS to visualize some of the model results.
 
 # References
 
-* Liao, Chang, Zhou, T., Xu, D., Cooper, M. G., Engwirda, D., Li, H.-Y., Leung, L. R. (2023). Topological relationship-based flow direction modeling: Mesh-independent river networks representation. Journal of Advances in Modeling Earth Systems, 15, e2022MS003089. https://doi.org/10.1029/2022MS003089
+- Liao, Chang, Zhou, T., Xu, D., Cooper, M. G., Engwirda, D., Li, H.-Y., Leung, L. R. (2023). Topological relationship-based flow direction modeling: Mesh-independent river networks representation. Journal of Advances in Modeling Earth Systems, 15, e2022MS003089. https://doi.org/10.1029/2022MS003089
 
-* Liao et al., (2023). pyflowline: a mesh-independent river network generator for hydrologic models. Journal of Open Source Software, 8(91), 5446, https://doi.org/10.21105/joss.05446
+- Liao and Cooper, (2023). pyflowline: a mesh-independent river network generator for hydrologic models. Journal of Open Source Software, 8(91), 5446, https://doi.org/10.21105/joss.05446
 
-* Liao. C. (2022). Pyflowline: a mesh independent river network generator for hydrologic models. Zenodo. https://doi.org/10.5281/zenodo.6407299
+- Liao. C. (2022). Pyflowline: a mesh independent river network generator for hydrologic models. Zenodo. https://doi.org/10.5281/zenodo.6407299

--- a/check_environment.py
+++ b/check_environment.py
@@ -1,6 +1,15 @@
 import importlib
 
-packages = ['pyearth', 'cartopy', 'matplotlib', 'numpy','geopandas','libgdal-arrow-parquet','pyearth','pyflowline']
+packages = [
+    "pyearth",
+    "cartopy",
+    "matplotlib",
+    "numpy",
+    "geopandas",
+    "libgdal-arrow-parquet",
+    "pyearth",
+    "pyflowline",
+]
 
 bad = []
 for package in packages:
@@ -10,12 +19,15 @@ for package in packages:
         bad.append("Can't import %s" % package)
 else:
     if len(bad) > 0:
-        print('Your tutorial environment is not yet fully set up:')
-        print('\n'.join(bad))
+        print("Your tutorial environment is not yet fully set up:")
+        print("\n".join(bad))
     else:
         try:
             import geopandas
-            countries = geopandas.read_file("zip://./data/ne_110m_admin_0_countries.zip")
+
+            countries = geopandas.read_file(
+                "zip://./data/ne_110m_admin_0_countries.zip"
+            )
             print("All good. Enjoy the tutorial!")
         except Exception as e:
             print("Couldn't read countries shapefile.")

--- a/examples/yukon/run_dggrid_simulation.py
+++ b/examples/yukon/run_dggrid_simulation.py
@@ -6,45 +6,46 @@ from os.path import realpath
 import importlib.util
 from shutil import copy2
 from datetime import date
-#import geopandas as gpd
+
+# import geopandas as gpd
 import matplotlib.pyplot as plt
 import logging
 from dotenv import load_dotenv
 
-#%% setup logging
+# %% setup logging
 for handler in logging.root.handlers[:]:
     logging.root.removeHandler(handler)
 
-logging.basicConfig(format='%(asctime)s %(message)s')
-logging.warning('is the time pyflowline simulation started.')
+logging.basicConfig(format="%(asctime)s %(message)s")
+logging.warning("is the time pyflowline simulation started.")
 
-#%% Set the path to dggrid
+# %% Set the path to dggrid
 load_dotenv()
-sPath_dggrid_bin = os.getenv('DGGRID_BINARY_PATH')
+sPath_dggrid_bin = os.getenv("DGGRID_BINARY_PATH")
 os.environ["PATH"] += os.pathsep + sPath_dggrid_bin
 # Note - iFlag_user_provided_binary must be false
 
-#%% Set workspace paths
+# %% Set workspace paths
 sPath_parent = Path(__file__).resolve().parents[2]
 print(f"Parent path: {sPath_parent}")
 
-sWorkspace_data = os.path.join( sPath_parent, 'data', 'yukon')
+sWorkspace_data = os.path.join(sPath_parent, "data", "yukon")
 if not os.path.exists(sWorkspace_data):
     print(sWorkspace_data)
     os.makedirs(sWorkspace_data)
 
-sWorkspace_input = os.path.join( sWorkspace_data, 'input')
+sWorkspace_input = os.path.join(sWorkspace_data, "input")
 if not os.path.exists(sWorkspace_input):
     print(sWorkspace_input)
     os.makedirs(sWorkspace_input)
 
-sWorkspace_output = os.path.join( sWorkspace_data, 'output')
+sWorkspace_output = os.path.join(sWorkspace_data, "output")
 if not os.path.exists(sWorkspace_output):
     print(sWorkspace_output)
     os.makedirs(sWorkspace_output)
 
-#%% Setup temporary workspace for data
-sPath_temp = os.path.join( sPath_parent, 'data', 'tmp' )
+# %% Setup temporary workspace for data
+sPath_temp = os.path.join(sPath_parent, "data", "tmp")
 if not os.path.exists(sPath_temp):
     print(sPath_temp)
     os.makedirs(sPath_temp)
@@ -52,11 +53,11 @@ else:
     shutil.rmtree(sPath_temp)
 
 # Specify the repository's URL
-hexwatershed_data_repo = 'https://github.com/changliao1025/hexwatershed_data.git'
+hexwatershed_data_repo = "https://github.com/changliao1025/hexwatershed_data.git"
 
 # Clone the repository
-os.system(f'git clone {hexwatershed_data_repo} {sPath_temp}')
-sPath_temp_data = os.path.join(sPath_parent, 'data', 'tmp', 'data', 'yukon', 'input')
+os.system(f"git clone {hexwatershed_data_repo} {sPath_temp}")
+sPath_temp_data = os.path.join(sPath_parent, "data", "tmp", "data", "yukon", "input")
 
 # Check if the destination directory exists, if exists, remove it
 if os.path.exists(sWorkspace_input):
@@ -67,21 +68,23 @@ shutil.copytree(sPath_temp_data, sWorkspace_input)
 
 shutil.rmtree(sPath_temp)
 
-sFilename_configuration_in = os.path.join(sWorkspace_input, 'pyhexwatershed_yukon_dggrid.json')
-sFilename_basins_in = os.path.join(sWorkspace_input, 'pyflowline_yukon_basins.json')
+sFilename_configuration_in = os.path.join(
+    sWorkspace_input, "pyhexwatershed_yukon_dggrid.json"
+)
+sFilename_basins_in = os.path.join(sWorkspace_input, "pyflowline_yukon_basins.json")
 if os.path.isfile(sFilename_configuration_in):
     pass
 else:
-    print('The domain configuration file does not exist: ', sFilename_configuration_in)
+    print("The domain configuration file does not exist: ", sFilename_configuration_in)
 
-print('Finished the data preparation step.')
+print("Finished the data preparation step.")
 
-#%% Define the case parameters
-sRegion = 'yukon'
-sMesh_type = 'dggrid'
-sDggrid_type = 'ISEA3H'
+# %% Define the case parameters
+sRegion = "yukon"
+sMesh_type = "dggrid"
+sDggrid_type = "ISEA3H"
 iCase_index = 1
-iResolution_index = 10 # dggrid resolution index
+iResolution_index = 10  # dggrid resolution index
 
 # Get today's year, month and day.
 today = date.today()
@@ -91,78 +94,106 @@ iDay = today.day
 print("Today's date:", iYear, iMonth, iDay)
 sDate = str(iYear) + str(iMonth).zfill(2) + str(iDay).zfill(2)
 
-#%% Set the dggrid mesh resolution
+# %% Set the dggrid mesh resolution
 from pyflowline.mesh.dggrid.create_dggrid_mesh import dggrid_find_resolution_by_index
-dResolution = dggrid_find_resolution_by_index(sDggrid_type, iResolution_index)
-print('Mesh resolution is: ', dResolution, 'm')
 
-#%% Make copies of the configuration files
-sFilename_configuration_copy = os.path.join(sWorkspace_output, 'pyflowline_configuration_copy.json')
+dResolution = dggrid_find_resolution_by_index(sDggrid_type, iResolution_index)
+print("Mesh resolution is: ", dResolution, "m")
+
+# %% Make copies of the configuration files
+sFilename_configuration_copy = os.path.join(
+    sWorkspace_output, "pyflowline_configuration_copy.json"
+)
 copy2(sFilename_configuration_in, sFilename_configuration_copy)
 
 # Also copy the basin configuration file to the output directory.
-sFilename_basins_configuration_copy = os.path.join(sWorkspace_output, 'pyflowline_configuration_basins_copy.json')
+sFilename_basins_configuration_copy = os.path.join(
+    sWorkspace_output, "pyflowline_configuration_basins_copy.json"
+)
 copy2(sFilename_basins_in, sFilename_basins_configuration_copy)
 
-#%% Change configuration parameters
+# %% Change configuration parameters
 
 # The json file will be overwritten, you may want to make a copy of it first.
 sFilename_configuration = sFilename_configuration_copy
 sFilename_basins = sFilename_basins_configuration_copy
 
 from pyflowline.configuration.change_json_key_value import change_json_key_value
-change_json_key_value(sFilename_configuration, 'sWorkspace_output', sWorkspace_output) # Output folder
-change_json_key_value(sFilename_configuration, 'sFilename_basins', sFilename_basins) # Individual basin configuration file
+
+change_json_key_value(
+    sFilename_configuration, "sWorkspace_output", sWorkspace_output
+)  # Output folder
+change_json_key_value(
+    sFilename_configuration, "sFilename_basins", sFilename_basins
+)  # Individual basin configuration file
 
 # Set the domain boundary file, used to clip the mesh
-sFilename_mesh_boundary = realpath(os.path.join(sWorkspace_input, 'boundary.geojson'))
-change_json_key_value(sFilename_configuration, 'sFilename_mesh_boundary', sFilename_mesh_boundary)
+sFilename_mesh_boundary = realpath(os.path.join(sWorkspace_input, "boundary.geojson"))
+change_json_key_value(
+    sFilename_configuration, "sFilename_mesh_boundary", sFilename_mesh_boundary
+)
 
-#%% Read the configuration file
-from pyflowline.configuration.read_configuration_file import pyflowline_read_configuration_file
+# %% Read the configuration file
+from pyflowline.configuration.read_configuration_file import (
+    pyflowline_read_configuration_file,
+)
 
-oPyflowline = pyflowline_read_configuration_file(sFilename_configuration, iCase_index_in=iCase_index, sMesh_type_in=sMesh_type, iResolution_index_in=iResolution_index, sDate_in=sDate)
+oPyflowline = pyflowline_read_configuration_file(
+    sFilename_configuration,
+    iCase_index_in=iCase_index,
+    sMesh_type_in=sMesh_type,
+    iResolution_index_in=iResolution_index,
+    sDate_in=sDate,
+)
 
-#%% Update some parameters
+# %% Update some parameters
 
 # Set the approximate outlet location
 dLongitude_outlet_degree = -164.47594
 dLatitude_outlet_degree = 63.04269
 oPyflowline.aBasin[0].dThreshold_small_river = dResolution * 5
 
-oPyflowline.pyflowline_change_model_parameter('dLongitude_outlet_degree', dLongitude_outlet_degree, iFlag_basin_in=1)
-oPyflowline.pyflowline_change_model_parameter('dLatitude_outlet_degree', dLatitude_outlet_degree, iFlag_basin_in=1)
+oPyflowline.pyflowline_change_model_parameter(
+    "dLongitude_outlet_degree", dLongitude_outlet_degree, iFlag_basin_in=1
+)
+oPyflowline.pyflowline_change_model_parameter(
+    "dLatitude_outlet_degree", dLatitude_outlet_degree, iFlag_basin_in=1
+)
 
 # Set the path to the user provided flowline
-sFilename_flowline = realpath(os.path.join(sWorkspace_input, 'dggrid10/river_networks.geojson') )
-oPyflowline.pyflowline_change_model_parameter('sFilename_flowline_filter', sFilename_flowline, iFlag_basin_in= 1)
+sFilename_flowline = realpath(
+    os.path.join(sWorkspace_input, "dggrid10/river_networks.geojson")
+)
+oPyflowline.pyflowline_change_model_parameter(
+    "sFilename_flowline_filter", sFilename_flowline, iFlag_basin_in=1
+)
 
 # Turn debugging off
-oPyflowline.pyflowline_change_model_parameter('iFlag_debug', 0, iFlag_basin_in=1)
+oPyflowline.pyflowline_change_model_parameter("iFlag_debug", 0, iFlag_basin_in=1)
 
 # Set this flag false if the dggrid binary is on the system path, to let pyflowline find it. Set this flag true if the path to the binary file is set in the configuration file.
 oPyflowline.iFlag_user_provided_binary = 0
 
-#%% Setup the model
+# %% Setup the model
 
 oPyflowline.pyflowline_setup()
-oPyflowline.plot( sVariable_in = 'flowline_filter' )
+oPyflowline.plot(sVariable_in="flowline_filter")
 
-#%% Flowline simplification
+# %% Flowline simplification
 oPyflowline.pyflowline_flowline_simplification()
-oPyflowline.plot( sVariable_in = 'flowline_simplified' )
+oPyflowline.plot(sVariable_in="flowline_simplified")
 
-#%% Mesh generation
+# %% Mesh generation
 oPyflowline.iFlag_mesh_boundary = 1
 aCell = oPyflowline.pyflowline_mesh_generation()
-oPyflowline.plot( sVariable_in = 'mesh')
+oPyflowline.plot(sVariable_in="mesh")
 oPyflowline.pyflowline_reconstruct_topological_relationship()
 
-#%% Export the results
+# %% Export the results
 oPyflowline.pyflowline_export()
-oPyflowline.plot( sVariable_in = 'flowline_conceptual')
-oPyflowline.plot( sVariable_in = 'overlap')
+oPyflowline.plot(sVariable_in="flowline_conceptual")
+oPyflowline.plot(sVariable_in="overlap")
 oPyflowline.pyflowline_export_config_to_json()
 
 # %%
-print('Finished the simulation.')
+print("Finished the simulation.")

--- a/notebooks/yukon/dggrid_example.ipynb
+++ b/notebooks/yukon/dggrid_example.ipynb
@@ -18,9 +18,11 @@
     "\n",
     "This tutorial serves as an example of the PyFlowline application using a DGGRID (Discrete Global Grid) mesh.\n",
     "\n",
+    "For comprehensive documentation of PyFlowline, please visit the [PyFlowline Documentation](https://pyflowline.readthedocs.io/en/latest/).\n",
+    "\n",
     "For additional information on this application and the DGGRID mesh, please refer to the following publication:\n",
     "\n",
-    "Liao, C., Engwirda, D., Cooper, M., Li, M., and Fang, Y.: Discrete Global Grid System-based Flow Routing Datasets in the Amazon and Yukon Basins, Earth Syst. Sci. Data Discuss. [preprint], https://doi.org/10.5194/essd-2023-398, in review, 2024.\n",
+    "Liao, C., Engwirda, D., Cooper, M., Li, M., and Fang, Y.: Discrete Global Grid System-based Flow Routing Datasets in the Amazon and Yukon Basins, Earth Syst. Sci. Data Discuss. [preprint](https://doi.org/10.5194/essd-2023-398), in review, 2024.\n",
     "\n",
     "If you are running this notebook directly from the Binder platform, then all the dependencies are already installed. Otherwise, you must install the PyFlowline package and its dependencies (and/or update your existing installation/environment). Additionally, visualization requires optional dependency packages (refer to the full documentation installation section).\n",
     "\n",
@@ -111,9 +113,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# If running locally, replace this with the path to the folder containing the dggrid binary\n",
-    "sPath_dggrid_bin = os.pathsep + \"/home/jovyan/\"\n",
-    "os.environ[\"PATH\"] += sPath_dggrid_bin"
+    "sPath_dggrid_bin = os.pathsep + \"/home/jovyan/\" # this is the path on Binder\n",
+    "os.environ[\"PATH\"] += sPath_dggrid_bin\n",
+    "\n",
+    "# If running locally, open the .env file and set the path to the folder containing the dggrid binary\n",
+    "# from dotenv import load_dotenv\n",
+    "# load_dotenv()\n",
+    "# sPath_dggrid_bin = os.getenv(\"DGGRID_BINARY_PATH\")\n",
+    "# os.environ[\"PATH\"] += os.pathsep + sPath_dggrid_bin"
    ]
   },
   {


### PR DESCRIPTION
This PR contains a few updates leftover from the CSDMS demo which were not pushed.

The changes are almost entirely to the README, to clearly explain how to use the Binder notebook versus running locally.

I also added a commented-out explanation to the dggrid_example Jupyter notebook which describes how to use the .env file to set the dggrid binary path locally.

No changes to actual functionality are included, so you can merge this without review, or feel free to suggest changes.